### PR TITLE
fix bug related to caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ab-test-hooks",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A fast and lightweight AB-Testing library for React and Next.js based on hooks and functional components",
   "author": "NiklasMencke",
   "license": "MIT",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -75,6 +75,7 @@ const getWeightedRandomInt = (spec: any): number => {
       table.push(i);
     }
   }
+  console.log(table, Number(table[Math.floor(Math.random() * table.length)]))
   return Number(table[Math.floor(Math.random() * table.length)]);
 };
 
@@ -109,7 +110,13 @@ const useVariant = ({
   error: string | null;
 } => {
   const [resultIndex, setResultIndex] = useState<number>(
-    cacheResult ? (Number(getVariantFromStorage(id)) !== NaN ? Number(getVariantFromStorage(id)) : -1) : -1,
+    () => {
+      if (cacheResult) {
+        const savedVariant = getVariantFromStorage(id);
+        if (typeof savedVariant === "string") return Number(getVariantFromStorage(id));
+      }
+      return -1;
+    }
   );
   const [error, setError] = useState<string | null>(null);
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -109,7 +109,7 @@ const useVariant = ({
   error: string | null;
 } => {
   const [resultIndex, setResultIndex] = useState<number>(
-    cacheResult ? (Number(getVariantFromStorage(id)) ? Number(getVariantFromStorage(id)) : -1) : -1,
+    cacheResult ? (Number(getVariantFromStorage(id)) !== NaN ? Number(getVariantFromStorage(id)) : -1) : -1,
   );
   const [error, setError] = useState<string | null>(null);
 


### PR DESCRIPTION
Hi @NiklasMencke first of all thank you for this library.

Although I have found one bug in. It is related to caching logic when `cached: true`. If variant `A` is selected it is saved as 0 in the local storage, but when it retrieved from it is checked using `(Number(getVariantFromStorage(id))` that will result in `Number("0")` which is false hence `-1` will be returned, hence it will be considered as nothing is stored and new variant will be chosen with a possibility of rewriting previous variant.

Please, would you be able to apply this fix provided in this PR, or let me know your thoughts. 